### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ The following is the definition document for the Humidity Object in XML.
 				<Operations>R</Operations>
 				<MultipleInstances>Single</MultipleInstances>
 				<Mandatory>Optional</Mandatory>
-				<Type>String</Type>
+				<Type>Float</Type>
 				<RangeEnumeration></RangeEnumeration>
 				<Units>Defined by “Units” resource.</Units>
 				<Description>The minimum value that can be measured by the sensor</Description>


### PR DESCRIPTION
in section 4.2, in the xml definition, "Min Range Value" type has been modified to "Float"